### PR TITLE
Githubにpublicの画像がアップロードされないように設定

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@
 
 # Ignore master key for decrypting credentials and more.
 /config/master.key
+
+# Ignore Upload command history file.
+public/uploads/*


### PR DESCRIPTION
# what
.gitignoreファイルにpublic/uploads/*を追加

# why
public/uploads/の画像がgithubに上がらないようにするため