### PR TITLE
出品ページの販売価格JS実装

### DIFF
--- a/app/assets/javascripts/new.js
+++ b/app/assets/javascripts/new.js
@@ -1,13 +1,27 @@
 $(function(){
-  $('#price-form').on('keyup',function(){
-    var input = $(this).val();
-   
-    var fee = input * 0.1
-    $('#sellfee').html('¥' + fee)
- 
-    var profit = input * 0.9
-    $('#sellprofit').html('¥' + profit)
-    
 
+  $('#price-form').on('keyup', function(e){
+    var k = e.keyCode;
+    var input = $(this).val()
+
+    if (input.search(/^[-]?[0-9]+$([3-9][0-9][0-9]|9999999)/) == 0 ) {
+      
+      var fee = input * 0.1 
+      //Math.floor 小数点切り下げ
+      fee = String(Math.floor(fee)).replace( /(\d)(?=(\d\d\d)+(?!\d))/g, '$1,');
+      $('#sellfee').html("¥" + fee)
+
+      var profit = input * 0.9
+      //Math.ceil 少数点切り上げ
+      profit = String(Math.ceil(profit)).replace( /(\d)(?=(\d\d\d)+(?!\d))/g, '$1,');
+      $('#sellprofit').html("¥" + profit)
+
+    } else {
+      $('#sellfee').html('-')
+      $('#sellprofit').html('-')
+    }
   })
-})
+});
+
+// var input = input >= 300 && input <= 9999999
+// (300..9999999).include?this

--- a/app/assets/javascripts/new.js
+++ b/app/assets/javascripts/new.js
@@ -4,7 +4,8 @@ $(function(){
     var k = e.keyCode;
     var input = $(this).val()
 
-    if (input.search(/^[-]?[0-9]+$([3-9][0-9][0-9]|9999999)/) == 0 ) {
+    //販売価格300〜9,999,999、半角数字以外は入力不可
+    if (input.search((/^[-]?[0-9]+$/) == 0 ) && (input >= 300 && input <= 9999999)) {
       
       var fee = input * 0.1 
       //Math.floor 小数点切り下げ
@@ -22,6 +23,3 @@ $(function(){
     }
   })
 });
-
-// var input = input >= 300 && input <= 9999999
-// (300..9999999).include?this

--- a/app/assets/javascripts/new.js
+++ b/app/assets/javascripts/new.js
@@ -1,4 +1,4 @@
-$(function(){
+$(document).on('turbolinks:load',function(){
 
   $('#price-form').on('keyup', function(e){
     var k = e.keyCode;

--- a/app/assets/javascripts/new.js
+++ b/app/assets/javascripts/new.js
@@ -1,0 +1,13 @@
+$(function(){
+  $('#price-form').on('keyup',function(){
+    var input = $(this).val();
+   
+    var fee = input * 0.1
+    $('#sellfee').html('¥' + fee)
+ 
+    var profit = input * 0.9
+    $('#sellprofit').html('¥' + profit)
+    
+
+  })
+})

--- a/app/assets/javascripts/new.js
+++ b/app/assets/javascripts/new.js
@@ -1,7 +1,6 @@
 $(document).on('turbolinks:load',function(){
 
-  $('#price-form').on('keyup', function(e){
-    var k = e.keyCode;
+  $('#price-form').on('keyup', function(){
     var input = $(this).val()
 
     //販売価格300〜9,999,999、半角数字以外は入力不可

--- a/app/assets/stylesheets/items/new.scss
+++ b/app/assets/stylesheets/items/new.scss
@@ -77,4 +77,8 @@
       padding: 24px 0;
     }
   }
+  .sell-notice {
+    @include item-aHover;
+  }
 }
+

--- a/app/views/items/new.html.haml
+++ b/app/views/items/new.html.haml
@@ -131,14 +131,14 @@
                 .single__field__label__right
                   %p ¥
                   .single__field__input.single__field__input--right.text-right
-                    = f.text_field :price, placeholder: "例) 300" ,class:"text-right"
+                    = f.text_field :price, placeholder: "例) 300" ,class:"text-right", id:"price-form"
                  
             %li.sellfee 
               .l-left 販売手数料
-              .l-right
+              .l-right#sellfee -
             %li.sellprofit 
               .l-left 販売利益
-              .l-right 
+              .l-right#sellprofit -
 
       .sell-content
         .sell--box

--- a/app/views/items/new.html.haml
+++ b/app/views/items/new.html.haml
@@ -141,13 +141,24 @@
               .l-right#sellprofit -
 
       .sell-content
-        .sell--box
-          %p 禁止されている出品、行為を必ずご確認ください。
-          %p またブランド品でシリアルナンバー等がある場合はご記載ください。偽ブランドの販売は犯罪であり処罰される可能性があります。
-          %p また、出品をもちまして加盟店規約に同意したことになります。
+        %div
+          %p.single__field__text
+            = link_to "禁止されている出品", "https://www.mercari.com/jp/help_center/getting_started/prohibited_items/" , class:"sell-notice"
+            、
+            = link_to "行為", "https://www.mercari.com/jp/help_center/getting_started/prohibited_conduct/", class:"sell-notice"
+            を必ずご確認ください。
+        
+            %br
+            またブランド品でシリアルナンバー等がある場合はご記載ください。
+            = link_to "偽ブランドの販売", "https://www.mercari.com/jp/help_center/getting_started/counterfeit_goods/", class:"sell-notice"
+            は犯罪であり処罰される可能性があります。
+          
+            %br
+            また、出品をもちまして
+            = link_to "加盟店規約", "https://www.mercari.com/jp/seller_terms/", class:"sell-notice"
+            に同意したことになります。
 
-          %p.single__field__text.single__field__text--center
-          = f.submit "出品する", class: "single__form__send-btn" 
-          = link_to root_path do
-            = f.submit "もどる", class: "single__form__send-btn single__form__send-btn--gray single__form__send-btn--small" 
-     
+        = f.submit "出品する", class: "single__form__send-btn" 
+        = link_to root_path do
+          = f.submit "もどる", class: "single__form__send-btn single__form__send-btn--gray single__form__send-btn--small" 
+    


### PR DESCRIPTION
# what
商品出品ページの販売価格JS実装
・販売価格を入力すると手数料、利益が自動表示されるように実装
・入力できる価格を300〜9,999,999円に設定
・価格に3桁区切りを設定
・注意事項のリンク貼り

# why
手数料を引いた販売利益をリアルタイムで確認できるようにするため
