### PR TITLE
sold追加・商品周りのbefore_action追加

### DIFF
--- a/app/assets/stylesheets/items/show.scss
+++ b/app/assets/stylesheets/items/show.scss
@@ -34,6 +34,25 @@
         margin: 0 auto;
         position: relative;
         overflow: hidden;
+        &__soldout{
+          position: absolute;
+          top: 0;
+          left: 0;
+          z-index: 4;
+          border-style: solid;
+          border-width: 120px 120px 0 0;
+          border-color: #EA352D transparent transparent transparent;
+          h2{
+            font-size: 22px;
+            color: #fff;
+            letter-spacing: 2px;
+            font-weight: bold;
+            transform: rotate(-45deg);
+            position: absolute;
+            top: -100px;
+            z-index: 5;
+          }
+        }
         &__slide{
           display: flex;
           position: absolute;

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -140,8 +140,8 @@ class ItemsController < ApplicationController
     @grandchild = Category.find(@item.category_id)
   end
 
-  def authenticate
-    redirect_to new_user_session_path
+  def authenticate  
+    redirect_to new_user_session_path unless user_signed_in?
   end
 end
   

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,6 +1,7 @@
 class ItemsController < ApplicationController
   # before_action :user_signed_in?, only:[:new, :create, :edit, :update, :destroy]
   before_action :set_item, only:[:show, :edit, :update, :destroy, :buy, :pay]
+  before_action :authenticate, only:[:new, :edit, :done, :buy]
 
   def index
     @items = Item.includes(:images).order("created_at desc").limit(8)
@@ -139,5 +140,8 @@ class ItemsController < ApplicationController
     @grandchild = Category.find(@item.category_id)
   end
 
+  def authenticate
+    redirect_to new_user_session_path
+  end
 end
   

--- a/app/views/categories/_cate-item.html.haml
+++ b/app/views/categories/_cate-item.html.haml
@@ -7,7 +7,7 @@
         -if image
           =image_tag "#{image.image}"
         -if item.status >= 1
-          .items-box__photo__soldout
+          .cateItem-box__photo__soldout
             %h2 SOLD
       .cateItem-box__body
         %h3{class: "cateItem-box__body__name font-2"}

--- a/app/views/items/buy.html.haml
+++ b/app/views/items/buy.html.haml
@@ -21,21 +21,22 @@
             支払い金額
             %span 
               ="¥ #{@item.price}"
-          -if @card
-            -if @item.status == 0
-              =form_for @item, url: {controller: "items", action: "pay"} do |f|
-                = f.text_field :status, value: 1, class: "purchase-form-hidden"
-                = f.text_field :buyer_id, value: current_user.id, class: "purchase-form-hidden"
-                %button.purchase-button{type: "submit"}
-                  購入する
+          -unless @item.seller_id.to_s == current_user&.id.to_s
+            -if @card
+              -if @item.status == 0
+                =form_for @item, url: {controller: "items", action: "pay"} do |f|
+                  = f.text_field :status, value: 1, class: "purchase-form-hidden"
+                  = f.text_field :buyer_id, value: current_user.id, class: "purchase-form-hidden"
+                  %button.purchase-button{type: "submit"}
+                    購入する
+              -else
+                %button.purchase-button--sold
+                  売り切れです
             -else
+              %p.purchase-button__notice
+                支払い方法を登録してください
               %button.purchase-button--sold
-                売り切れです
-          -else
-            %p.purchase-button__notice
-              支払い方法を登録してください
-            %button.purchase-button--sold
-              購入する
+                購入する
 
   
       -# ユーザーのデータベースができてから表示

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -5,6 +5,9 @@
       = @item.name
     .item__main-content
       .item__photo
+        - if @item.status >= 1
+          .item__photo__soldout
+            %h2 SOLD
         .item__photo__slide
           -@item.images.each do |image|
             =image_tag "#{image.image}", class: "item__photo__slide__img"

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -87,12 +87,13 @@
         (税込)
       %span.item__price-box__shipping-fee
         送料込み
-    -if @item.status == 0
-      =link_to items_buy_path, class: "item__buy-btn" do
-        購入画面に進む
-    - else
-      %button.item__buy-btn--sold
-        売り切れです
+    -unless @item.seller_id.to_s == current_user&.id.to_s
+      -if @item.status == 0
+        =link_to items_buy_path, class: "item__buy-btn" do
+          購入画面に進む
+      - else
+        %button.item__buy-btn--sold
+          売り切れです
 
     %section.item__description
       %p.item__description__innner


### PR DESCRIPTION
# what
詳細ページとカテゴリーページにsold表示の追加
before_actionでサインインしてない場合にサインインページに飛ぶように（出品編集購入ページ）
# why
売れた商品がわかりやすくなる
サインインしてないユーザーが出品などをできないように